### PR TITLE
Implement list_use_statements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,9 @@ name = "extricrate"
 version = "0.0.1"
 dependencies = [
  "pretty_assertions",
+ "quote",
+ "syn",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -318,7 +321,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -326,6 +338,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -381,7 +404,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee40835db14ddd1e3ba414292272eddde9dad04d3d4b65509656414d1c42592f"
 dependencies = [
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
  "tracing-subscriber",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,7 @@ name = "extricrate"
 version = "0.0.1"
 dependencies = [
  "pretty_assertions",
+ "proc-macro2",
  "quote",
  "syn",
  "thiserror 2.0.12",

--- a/crates/extricrate/Cargo.toml
+++ b/crates/extricrate/Cargo.toml
@@ -12,7 +12,8 @@ repository.workspace = true
 
 [dependencies]
 quote = "1.0.40"
-syn = { version = "2.0.101", features = ["full", "visit"] }
+syn = { version = "2.0.101", features = ["full", "visit", "extra-traits"] }
+proc-macro2 = { version = "1.0.95", features = ["span-locations"] }
 thiserror = "2.0.12"
 tracing.workspace = true
 

--- a/crates/extricrate/Cargo.toml
+++ b/crates/extricrate/Cargo.toml
@@ -11,6 +11,9 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+quote = "1.0.40"
+syn = { version = "2.0.101", features = ["extra-traits", "full", "parsing", "printing", "visit"] }
+thiserror = "2.0.12"
 tracing.workspace = true
 
 [dev-dependencies]

--- a/crates/extricrate/Cargo.toml
+++ b/crates/extricrate/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 
 [dependencies]
 quote = "1.0.40"
-syn = { version = "2.0.101", features = ["extra-traits", "full", "parsing", "printing", "visit"] }
+syn = { version = "2.0.101", features = ["full", "visit"] }
 thiserror = "2.0.12"
 tracing.workspace = true
 

--- a/crates/extricrate/src/lib.rs
+++ b/crates/extricrate/src/lib.rs
@@ -55,7 +55,7 @@ pub mod dependencies {
     pub struct UseStatement {
         /// Where the use statement appears.
         source_module: ModuleName,
-        /// List of referenced inner modules.
+        /// List of referenced modules.
         /// Several targets, to represent `use crate::{log, foo::{bar, baz}};`
         target_modules: Vec<ModuleName>,
         /// Where in the source file the use statement is.

--- a/crates/extricrate/src/lib.rs
+++ b/crates/extricrate/src/lib.rs
@@ -53,7 +53,7 @@ pub mod dependencies {
         /// Several targets, to represent `use crate::{log, foo::{bar, baz}};`
         target_modules: Vec<ModuleName>,
         /// Where in the source file the use statement is.
-        statements: Vec<UseStatementDetail>,
+        statement: UseStatementDetail,
     }
 
     pub type UseStatements = Vec<UseStatement>;
@@ -235,7 +235,7 @@ pub mod dependencies {
                     UseStatement {
                         source_module: ModuleName::new(file_to_visit.1.clone()),
                         target_modules,
-                        statements: vec![UseStatementDetail { items, extent }],
+                        statement: UseStatementDetail { items, extent },
                     }
                 })
                 .collect();
@@ -308,7 +308,7 @@ pub mod dependencies {
             let res = list_use_statements(&test_project).expect("Failed to list statements");
             let mut expected = HashMap::new();
 
-            let main_module_statements_module_a = vec![UseStatementDetail {
+            let main_module_statements_module_a = UseStatementDetail {
                 items: vec![NormalizedUseStatement {
                     module_name: ModuleName::new("crate".to_owned()),
                     statement_type: UseStatementType::Simple("module_a".to_owned()),
@@ -317,9 +317,9 @@ pub mod dependencies {
                     start: LineColumn { line: 1, column: 0 },
                     end: LineColumn { line: 1, column: 3 },
                 },
-            }];
+            };
 
-            let module_b_statements = vec![UseStatementDetail {
+            let module_b_statements = UseStatementDetail {
                 items: vec![NormalizedUseStatement {
                     module_name: ModuleName::new("std::collections".to_owned()),
                     statement_type: UseStatementType::Simple("HashMap".to_owned()),
@@ -328,13 +328,13 @@ pub mod dependencies {
                     start: LineColumn { line: 1, column: 0 },
                     end: LineColumn { line: 1, column: 3 },
                 },
-            }];
+            };
             expected.insert(
                 File("src/module_a/mod.rs".to_owned()),
                 vec![UseStatement {
                     source_module: ModuleName::new("module_a".to_owned()),
                     target_modules: vec![ModuleName::new("std::collections".to_owned())],
-                    statements: module_b_statements,
+                    statement: module_b_statements,
                 }],
             );
             expected.insert(
@@ -342,7 +342,7 @@ pub mod dependencies {
                 vec![UseStatement {
                     source_module: ModuleName::new("main".to_owned()),
                     target_modules: vec![ModuleName::new("crate".to_owned())],
-                    statements: main_module_statements_module_a,
+                    statement: main_module_statements_module_a,
                 }],
             );
             assert_eq!(res, expected);

--- a/crates/extricrate/src/lib.rs
+++ b/crates/extricrate/src/lib.rs
@@ -140,7 +140,7 @@ pub mod dependencies {
     }
 
     pub fn get_crate_entrypoint(crate_root: &Path) -> Option<PathBuf> {
-        // TODO: support custom entry point
+        // TODO: support multiple targets and custom paths different than src/main.rs or src/lib.rs
 
         let cargo_toml = crate_root.join("Cargo.toml");
         if !cargo_toml.exists() {

--- a/crates/extricrate/src/lib.rs
+++ b/crates/extricrate/src/lib.rs
@@ -12,8 +12,8 @@ pub mod dependencies {
     #[derive(Debug, PartialEq, Eq)]
     pub struct ModuleName(String);
     impl ModuleName {
-        fn new(name: &str) -> Self {
-            Self(name.to_owned())
+        fn new(name: String) -> Self {
+            Self(name)
         }
     }
 
@@ -170,14 +170,14 @@ pub mod dependencies {
             expected.insert(
                 File("src/main.rs".to_owned()),
                 vec![UseStatement {
-                    source_module: ModuleName::new("main"),
-                    target_modules: vec![ModuleName::new("std::collections::HashMap")],
+                    source_module: ModuleName::new("main".to_owned()),
+                    target_modules: vec![ModuleName::new("std::collections::HashMap".to_owned())],
                     extent: Extent {
                         start: Position { line: 1, col: 1 },
                         end: Position { line: 1, col: 31 },
                     },
                     normalized_statements: vec![NormalizedUseStatement {
-                        module_name: ModuleName::new("main"),
+                        module_name: ModuleName::new("main".to_owned()),
                         statement_type: UseStatementType::Simple(
                             "std::collections::HashMap".to_owned(),
                         ),

--- a/crates/extricrate/src/lib.rs
+++ b/crates/extricrate/src/lib.rs
@@ -81,6 +81,7 @@ pub mod dependencies {
         }
     }
 
+    // TODO: Visit also `mod` nodes, otherwise we would be missing some modules
     impl<'ast> Visit<'ast> for UseVisitor {
         fn visit_item_use(&mut self, node: &'ast ItemUse) {
             let tokens = node.to_token_stream();

--- a/crates/extricrate/src/lib.rs
+++ b/crates/extricrate/src/lib.rs
@@ -173,8 +173,8 @@ pub mod dependencies {
                     source_module: ModuleName::new("main"),
                     target_modules: vec![ModuleName::new("std::collections::HashMap")],
                     extent: Extent {
-                        start: Position { line: 1, col: 0 },
-                        end: Position { line: 1, col: 30 },
+                        start: Position { line: 1, col: 1 },
+                        end: Position { line: 1, col: 31 },
                     },
                     normalized_statements: vec![NormalizedUseStatement {
                         module_name: ModuleName::new("main"),

--- a/crates/extricrate/src/lib.rs
+++ b/crates/extricrate/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod dependencies {
     use std::collections::{HashMap, HashSet, VecDeque};
     use std::fs::read_to_string;
+    use std::path::{Path, PathBuf};
 
     use quote::ToTokens;
     use syn::visit::{self, Visit};
@@ -46,7 +47,7 @@ pub mod dependencies {
         /// `use crate::log::Bar as Baz;`
         Alias(String, String),
         /// `use crate::log::*;`
-        WildCard,
+        WildCard(String),
     }
 
     #[derive(Debug, PartialEq, Eq)]
@@ -114,7 +115,7 @@ pub mod dependencies {
             }
 
             UseTree::Glob(UseGlob { .. }) => {
-                vec![UseStatementType::WildCard]
+                vec![UseStatementType::WildCard(prefix.to_owned())]
             }
 
             UseTree::Group(UseGroup { items, .. }) => items
@@ -132,17 +133,46 @@ pub mod dependencies {
         FileNotParsable,
         #[error("file not readable")]
         FileNotReadable,
+        #[error("path is not a crate")]
+        PathIsNotACrate,
+        #[error("linked module does not exists: {0}")]
+        ModuleDoesNotExists(String),
+    }
+
+    pub fn get_crate_entrypoint(crate_root: &Path) -> Option<PathBuf> {
+        // TODO: support custom entry point
+
+        let cargo_toml = crate_root.join("Cargo.toml");
+        if !cargo_toml.exists() {
+            return None;
+        }
+
+        let main_rs = crate_root.join(Path::new("src/main.rs"));
+        if main_rs.exists() {
+            return Some(main_rs);
+        }
+
+        let lib_rs = crate_root.join(Path::new("src/lib.rs"));
+        if lib_rs.exists() {
+            return Some(lib_rs);
+        };
+        None
     }
 
     /// List all the `use` statements in the crate, by file/module.
     pub fn list_use_statements(
-        crate_root: &std::path::Path,
+        crate_root: &Path,
     ) -> Result<UseStatementMap, ListUseStatementError> {
         let mut files_visited = HashSet::new();
         let mut files_to_visit = VecDeque::new();
-        files_to_visit.push_back(crate_root);
+        let entry_point =
+            get_crate_entrypoint(crate_root).ok_or(ListUseStatementError::PathIsNotACrate)?;
+        let src_folder = entry_point
+            .parent()
+            .expect("Failed to get entry point parent folder");
+        files_to_visit.push_back(entry_point.clone());
         while let Some(file_to_visit) = files_to_visit.pop_front() {
-            if files_visited.contains(file_to_visit) {
+            if files_visited.contains(&file_to_visit) {
                 continue;
             }
 
@@ -150,7 +180,7 @@ pub mod dependencies {
                 return Err(ListUseStatementError::FileNotFound);
             }
 
-            let content = read_to_string(file_to_visit)
+            let content = read_to_string(&file_to_visit)
                 .map_err(|_| ListUseStatementError::FileNotReadable)?;
 
             let parsed_file =
@@ -159,13 +189,49 @@ pub mod dependencies {
             let mut visitor = UseVisitor::new();
             visitor.visit_file(&parsed_file);
             for dependency in visitor.dependencies {
-                // TODO: check if the dependency is local to the crate. if so, and it hasn't been
-                // visited before, add it to the list
+                match dependency {
+                    UseStatementType::Simple(name) => {
+                        if is_local_import(&name) {
+                            let file_to_visit = get_path_from_module_name(src_folder, &name)
+                                .ok_or(ListUseStatementError::ModuleDoesNotExists(name))?;
+                            files_to_visit.push_back(file_to_visit);
+                        }
+                    }
+                    UseStatementType::Alias(name, _) => todo!(),
+                    UseStatementType::WildCard(name) => todo!(),
+                }
             }
             files_visited.insert(file_to_visit);
         }
 
         todo!();
+    }
+
+    fn get_path_from_module_name(src_folder: &Path, name: &str) -> Option<PathBuf> {
+        let relative_path = name.strip_prefix("crate::").unwrap_or(name);
+        let relative_path = relative_path
+            .strip_prefix("my_crate::")
+            .unwrap_or(relative_path);
+        let mut base = src_folder.to_path_buf();
+        for segment in relative_path.split("::") {
+            base.push(segment);
+        }
+
+        let mut mod_rs = base.clone().join("mod");
+        mod_rs.set_extension("rs");
+        if mod_rs.exists() {
+            return Some(mod_rs);
+        }
+
+        base.set_extension("rs");
+        if base.exists() {
+            return Some(base);
+        }
+        None
+    }
+
+    fn is_local_import(name: &str) -> bool {
+        name.starts_with("crate::") || name.starts_with("my_crate::")
     }
 
     pub type ModuleDependencies = HashMap<ModuleName, Vec<ModuleName>>;
@@ -188,8 +254,7 @@ pub mod dependencies {
 
         #[test]
         fn get_simple_dependency() {
-            let test_project =
-                Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/simple/main.rs");
+            let test_project = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/simple/");
             let res = list_use_statements(&test_project).expect("Failed to list statements");
             let mut expected = HashMap::new();
             expected.insert(
@@ -215,10 +280,12 @@ pub mod dependencies {
 }
 
 pub mod refactor {
+    use std::path::Path;
+
     use crate::dependencies::{ModuleName, UseStatementMap};
 
     pub fn extract_crate(
-        crate_root: &std::path::Path,
+        crate_root: &Path,
         module: &ModuleName,
         target_crate_name: &str,
         target_crate_root: &std::path::Path,

--- a/crates/extricrate/src/lib.rs
+++ b/crates/extricrate/src/lib.rs
@@ -232,8 +232,7 @@ pub mod dependencies {
             let statements = visitor
                 .statements
                 .into_iter()
-                .map(|statement| {
-                    let UseStatementDetail { items, extent } = statement;
+                .map(|UseStatementDetail { items, extent }| {
                     let target_modules =
                         items.iter().map(|item| item.module_name.clone()).collect();
 

--- a/crates/extricrate/src/lib.rs
+++ b/crates/extricrate/src/lib.rs
@@ -221,7 +221,6 @@ pub mod dependencies {
                             let file_to_visit = get_path_from_module_name(src_folder, name).ok_or(
                                 ListUseStatementError::ModuleDoesNotExists(name.to_string()),
                             )?;
-                            dbg!(&files_to_visit);
                             files_to_visit.push_back((file_to_visit, name.to_owned()));
                         }
                     }

--- a/crates/extricrate/src/lib.rs
+++ b/crates/extricrate/src/lib.rs
@@ -7,6 +7,7 @@ pub mod dependencies {
 
     use proc_macro2::LineColumn;
     use quote::ToTokens;
+    use syn::spanned::Spanned;
     use syn::visit::{self, Visit};
     use syn::{
         Ident, ItemUse, UseGlob, UseGroup, UseName, UsePath, UseRename, UseTree, parse_file,
@@ -95,8 +96,8 @@ pub mod dependencies {
             self.statements.push(UseStatementDetail {
                 items,
                 extent: Extent {
-                    start: node.use_token.span.start(),
-                    end: node.use_token.span.end(),
+                    start: node.span().start(),
+                    end: node.span().end(),
                 },
             });
 
@@ -319,7 +320,10 @@ pub mod dependencies {
                 }],
                 extent: Extent {
                     start: LineColumn { line: 1, column: 0 },
-                    end: LineColumn { line: 1, column: 3 },
+                    end: LineColumn {
+                        line: 1,
+                        column: 20,
+                    },
                 },
             };
 
@@ -330,7 +334,10 @@ pub mod dependencies {
                 }],
                 extent: Extent {
                     start: LineColumn { line: 1, column: 0 },
-                    end: LineColumn { line: 1, column: 3 },
+                    end: LineColumn {
+                        line: 1,
+                        column: 30,
+                    },
                 },
             };
             expected.insert(

--- a/crates/extricrate/src/lib.rs
+++ b/crates/extricrate/src/lib.rs
@@ -238,6 +238,7 @@ pub mod dependencies {
                         items.iter().map(|item| item.module_name.clone()).collect();
 
                     UseStatement {
+                        // TODO: this is not the correct module if there is a scoped mod in the file
                         source_module: file_to_visit.1.clone().into(),
                         target_modules,
                         statement: UseStatementDetail { items, extent },

--- a/crates/extricrate/src/lib.rs
+++ b/crates/extricrate/src/lib.rs
@@ -209,10 +209,8 @@ pub mod dependencies {
     }
 
     fn get_path_from_module_name(src_folder: &Path, name: &str) -> Option<PathBuf> {
+        // TODO: Read crate name and strip also that from the prefix ie: my_crate::..
         let relative_path = name.strip_prefix("crate::").unwrap_or(name);
-        let relative_path = relative_path
-            .strip_prefix("my_crate::")
-            .unwrap_or(relative_path);
         let mut base = src_folder.to_path_buf();
         for segment in relative_path.split("::") {
             base.push(segment);
@@ -232,7 +230,8 @@ pub mod dependencies {
     }
 
     fn is_local_import(name: &str) -> bool {
-        name.starts_with("crate::") || name.starts_with("my_crate::")
+        //TODO: Read crate name and conside that local imports  ie: my_crate::..
+        name.starts_with("crate::")
     }
 
     pub type ModuleDependencies = HashMap<ModuleName, Vec<ModuleName>>;

--- a/crates/extricrate/src/lib.rs
+++ b/crates/extricrate/src/lib.rs
@@ -7,10 +7,10 @@ pub mod dependencies {
 
     use proc_macro2::LineColumn;
     use quote::ToTokens;
-    use syn::spanned::Spanned;
-    use syn::visit::{self, Visit};
     use syn::{
         Ident, ItemUse, UseGlob, UseGroup, UseName, UsePath, UseRename, UseTree, parse_file,
+        spanned::Spanned,
+        visit::{self, Visit},
     };
     use thiserror::Error;
 

--- a/crates/extricrate/src/lib.rs
+++ b/crates/extricrate/src/lib.rs
@@ -264,7 +264,6 @@ pub mod dependencies {
     }
 
     fn get_path_from_module_name(src_folder: &Path, name: &str) -> Option<PathBuf> {
-        // TODO: Read crate name and strip also that from the prefix ie: my_crate::..
         let relative_path = name.strip_prefix("crate::").unwrap_or(name);
         let mut base = src_folder.to_path_buf();
         for segment in relative_path.split("::") {

--- a/crates/extricrate/src/lib.rs
+++ b/crates/extricrate/src/lib.rs
@@ -284,7 +284,6 @@ pub mod dependencies {
     }
 
     fn is_local_import(name: &ModuleName) -> bool {
-        //TODO: Read crate name and conside that local imports  ie: my_crate::..
         name.0 == "crate" || name.0.starts_with("crate::")
     }
 

--- a/crates/extricrate/src/lib.rs
+++ b/crates/extricrate/src/lib.rs
@@ -399,12 +399,11 @@ pub mod dependencies {
             let file = syn::parse_file(src).unwrap();
             let mut visitor = UseVisitor::new();
             visitor.visit_file(&file);
-            let mut names: Vec<_> = visitor.statements[0]
+            let names: Vec<_> = visitor.statements[0]
                 .items
                 .iter()
                 .map(|i| (&i.module_name, &i.statement_type))
                 .collect();
-            names.sort_by_key(|(m, _)| m.0.clone());
             assert_eq!(
                 names,
                 vec![

--- a/crates/extricrate/src/lib.rs
+++ b/crates/extricrate/src/lib.rs
@@ -163,9 +163,9 @@ pub mod dependencies {
 
         #[test]
         fn get_simple_dependency() {
-            let fixture =
+            let test_project =
                 Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/simple/main.rs");
-            let res = list_use_statements(&fixture).expect("Failed to list statements");
+            let res = list_use_statements(&test_project).expect("Failed to list statements");
             let mut expected = HashMap::new();
             expected.insert(
                 File("src/main.rs".to_owned()),

--- a/crates/extricrate/src/lib.rs
+++ b/crates/extricrate/src/lib.rs
@@ -15,9 +15,15 @@ pub mod dependencies {
 
     #[derive(Debug, PartialEq, Eq, Clone)]
     pub struct ModuleName(String);
-    impl ModuleName {
-        fn new(name: String) -> Self {
-            Self(name)
+
+    impl From<String> for ModuleName {
+        fn from(value: String) -> Self {
+            Self(value)
+        }
+    }
+    impl From<&str> for ModuleName {
+        fn from(value: &str) -> Self {
+            Self(value.to_owned())
         }
     }
 
@@ -233,7 +239,7 @@ pub mod dependencies {
                         items.iter().map(|item| item.module_name.clone()).collect();
 
                     UseStatement {
-                        source_module: ModuleName::new(file_to_visit.1.clone()),
+                        source_module: file_to_visit.1.clone().into(),
                         target_modules,
                         statement: UseStatementDetail { items, extent },
                     }
@@ -298,7 +304,7 @@ pub mod dependencies {
         use proc_macro2::LineColumn;
 
         use crate::dependencies::{
-            Extent, File, ModuleName, NormalizedUseStatement, UseStatement, UseStatementDetail,
+            Extent, File, NormalizedUseStatement, UseStatement, UseStatementDetail,
             UseStatementType, list_use_statements,
         };
 
@@ -310,7 +316,7 @@ pub mod dependencies {
 
             let main_module_statements_module_a = UseStatementDetail {
                 items: vec![NormalizedUseStatement {
-                    module_name: ModuleName::new("crate".to_owned()),
+                    module_name: "crate".into(),
                     statement_type: UseStatementType::Simple("module_a".to_owned()),
                 }],
                 extent: Extent {
@@ -321,7 +327,7 @@ pub mod dependencies {
 
             let module_b_statements = UseStatementDetail {
                 items: vec![NormalizedUseStatement {
-                    module_name: ModuleName::new("std::collections".to_owned()),
+                    module_name: "std::collections".into(),
                     statement_type: UseStatementType::Simple("HashMap".to_owned()),
                 }],
                 extent: Extent {
@@ -332,16 +338,16 @@ pub mod dependencies {
             expected.insert(
                 File("src/module_a/mod.rs".to_owned()),
                 vec![UseStatement {
-                    source_module: ModuleName::new("module_a".to_owned()),
-                    target_modules: vec![ModuleName::new("std::collections".to_owned())],
+                    source_module: "module_a".into(),
+                    target_modules: vec!["std::collections".into()],
                     statement: module_b_statements,
                 }],
             );
             expected.insert(
                 File("src/main.rs".to_owned()),
                 vec![UseStatement {
-                    source_module: ModuleName::new("main".to_owned()),
-                    target_modules: vec![ModuleName::new("crate".to_owned())],
+                    source_module: "main".into(),
+                    target_modules: vec!["crate".into()],
                     statement: main_module_statements_module_a,
                 }],
             );

--- a/crates/extricrate/tests/fixtures/simple/main.rs
+++ b/crates/extricrate/tests/fixtures/simple/main.rs
@@ -1,0 +1,1 @@
+use std::collections::HashMap;

--- a/crates/extricrate/tests/fixtures/simple/main.rs
+++ b/crates/extricrate/tests/fixtures/simple/main.rs
@@ -1,1 +1,0 @@
-use std::collections::HashMap;

--- a/crates/extricrate/tests/fixtures/simple/src/main.rs
+++ b/crates/extricrate/tests/fixtures/simple/src/main.rs
@@ -1,3 +1,1 @@
 use crate::module_a;
-use crate::module_b;
-use std::collections::HashMap;

--- a/crates/extricrate/tests/fixtures/simple/src/main.rs
+++ b/crates/extricrate/tests/fixtures/simple/src/main.rs
@@ -1,0 +1,3 @@
+use crate::module_a;
+use crate::module_b;
+use std::collections::HashMap;

--- a/crates/extricrate/tests/fixtures/simple/src/module_a/mod.rs
+++ b/crates/extricrate/tests/fixtures/simple/src/module_a/mod.rs
@@ -1,1 +1,1 @@
-use std::collections::{Hashmap, VecQueue};
+use std::collections::HashMap;

--- a/crates/extricrate/tests/fixtures/simple/src/module_a/mod.rs
+++ b/crates/extricrate/tests/fixtures/simple/src/module_a/mod.rs
@@ -1,0 +1,1 @@
+use std::collections::{Hashmap, VecQueue};


### PR DESCRIPTION
First implementation of the list_use_statements function

Some things to keep a close eye on:
- crate_root is path to the filed as described here: https://doc.rust-lang.org/book/ch07-01-packages-and-crates.html 
- `list_use_statements` in now returning a `Result`
